### PR TITLE
fix(recursive-concat): se corrige expresión regular en la función makeNewFile

### DIFF
--- a/lib/gulp-recursive-concat.js
+++ b/lib/gulp-recursive-concat.js
@@ -82,7 +82,7 @@ RecursiveConcat.prototype.walk = function(file){
 };
 
 RecursiveConcat.prototype.makeNewFile = function(nameFile, file){
-	var regex = new RegExp(/([a-z_-]+\/|\\)/gi),
+	var regex = new RegExp(/([0-9a-z_-]+\/|\\)/gi),
 	basepath = file.path.replace(file.base, ""),
 	newPath = basepath.replace(/\\/g, "/"),
 	arrayBasePath = newPath.match(regex),


### PR DESCRIPTION
```
- La expresión regular adicionalmente acepta números en los nombres de carpeta.
```
