### PR TITLE
feat(lib): now, is not necessary to use "dist" option

### DIFF
--- a/lib/gulp-recursive-concat.js
+++ b/lib/gulp-recursive-concat.js
@@ -96,8 +96,8 @@ RecursiveConcat.prototype.makeNewFile = function(nameFile, file){
 
 	newFile = {
 		cwd: distBase,
-		base: distBase + this.options.dist,
-		path: this.options.dist + newBasepath + nameFile + this.options.extname,
+		base: distBase,
+		path: newBasepath + nameFile + this.options.extname,
 		contents: new Buffer(this.concat.content)
 	};
 


### PR DESCRIPTION
This option is the same when used, gulp.dest
