### PR TITLE
Opcion outside

### DIFF
--- a/lib/gulp-recursive-concat.js
+++ b/lib/gulp-recursive-concat.js
@@ -91,6 +91,9 @@ RecursiveConcat.prototype.makeNewFile = function(nameFile, file){
 	newBasepath = '';
 
 	if (arrayBasePath !== null) {
+		if(this.options.outside) {
+			arrayBasePath.pop();
+		}
 		newBasepath = arrayBasePath.join("");
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-recursive-concat",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "A gulp plugin for recursive concatenation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added the "outside" option to compile the concatenated file out of its containing folder.

```
recursiveConcat({outside: true})
```

```
INPUT
├── source
|   └── modules
|   |   └── default
|   |   |   └── index
|   |   |   |   └── modulo.js
```

```
OUTPUT
├── dist
|   └── modules
|   |   └── default
|   |   |   └── index.js
```
